### PR TITLE
Split sys output by first ':' only

### DIFF
--- a/autocheck.py
+++ b/autocheck.py
@@ -21,7 +21,7 @@ def get_system_info():
 
     resultlines = exec_crash_command("sys").splitlines()
     for line in resultlines:
-        words = line.split(":")
+        words = line.split(":", 1)
         sysinfo[words[0].strip()] = words[1].strip()
 
 


### PR DESCRIPTION
Current code can incorrectly parse Panic message if it contains ':', for example:
`       PANIC: "Kernel panic - not syncing: Timeout: Not all CPUs entered broadcast exception handler"`
